### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ fillScreen	KEYWORD2
 attachDraw	KEYWORD2
 getTick	KEYWORD2
 getLastTick	KEYWORD2
-getPeriod	KAYOWRD2
+getPeriod	KEYWORD2
 getFrequency KEYWORD2
 getLowerTick	KEYWORD2
 getHigherTick	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,7 +20,7 @@ attachDraw	KEYWORD2
 getTick	KEYWORD2
 getLastTick	KEYWORD2
 getPeriod	KEYWORD2
-getFrequency KEYWORD2
+getFrequency	KEYWORD2
 getLowerTick	KEYWORD2
 getHigherTick	KEYWORD2
 getLowerLastTick	KEYWORD2


### PR DESCRIPTION
- Correct invalid keywords.txt KEYWORD_TOKENTYPE
- Use correct field separator

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords